### PR TITLE
Support Rails 7 Virtual Columns

### DIFF
--- a/lib/fixturies.rb
+++ b/lib/fixturies.rb
@@ -114,7 +114,7 @@ class Fixturies
             }
 
             virtual_column_names = klass.columns.filter_map do |column|
-              if column.virtual?
+              if column.try(:virtual?)
                   column.name
               end
             end

--- a/lib/fixturies.rb
+++ b/lib/fixturies.rb
@@ -113,10 +113,20 @@ class Fixturies
                 self.inheritance_column = nil # do not blow up if the type column indicates we should be using single-table inheritance
             }
 
+            virtual_column_names = klass.columns.filter_map do |column|
+              if column.virtual?
+                  column.name
+              end
+            end
+
             hash = {}
             klass.all.each_with_index do |record, i|
                 name = record_identifiers[record_key(record)] || "#{table_name.singularize}_#{i}"
-                hash[name] = record.attributes
+                attributes = record.attributes
+                virtual_column_names.each do |column_name|
+                    attributes.delete(column_name)
+                end
+                hash[name] = attributes
             end
 
             if hash.any?


### PR DESCRIPTION
This gem is great and we use it over at @wantable with some of our larger test datasets. We came across a problem and figured we would share our solution!

Rails 7 now supports generated columns in Postgres: https://gist.github.com/zakariaf/534ff8dfc3a807779133dc078114b969#postgresql-generated-columns

But these attributes are not writeable and raises errors generating fixtures. This change detects those columns and ignores them. 